### PR TITLE
support .sass syntax fixes #34

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -27,5 +27,6 @@ test:
   override:
     - go list -f "{{range .TestImports}}{{.}} {{end}}" . | xargs -r go get
     - cd $PROJECT_ROOT && make test
-    - cd $PROJECT_ROOT && GIT_BRANCH=$CIRCLE_BRANCH goveralls -coverprofile=profile.cov -service=circleci -repotoken $COVERALLS_TOKEN
     - goxc -tasks='xc archive' -bc 'linux' -arch 'amd64' -d $CIRCLE_ARTIFACTS -n wt -wd wt
+  post:
+    - cd $PROJECT_ROOT && GIT_BRANCH=$CIRCLE_BRANCH goveralls -coverprofile=profile.cov -service=circleci -repotoken $COVERALLS_TOKEN

--- a/context/toscss.go
+++ b/context/toscss.go
@@ -5,6 +5,7 @@ package context
 import "C"
 
 import (
+	"bytes"
 	"io"
 	"io/ioutil"
 	"os"
@@ -13,10 +14,9 @@ import (
 )
 
 // ToScss converts Sass to Scss with libsass sass2scss.h
-func ToScss(r io.Reader) string {
+func ToScss(r io.Reader, w io.Writer) error {
 	bs, _ := ioutil.ReadAll(r)
 	in := C.CString(string(bs))
-
 	defer C.free(unsafe.Pointer(in))
 
 	chars := C.sass2scss(
@@ -25,8 +25,8 @@ func ToScss(r io.Reader) string {
 		// SASS2SCSS_PRETTIFY_1 Egyptian brackets
 		C.int(1),
 	)
-
-	return C.GoString(chars)
+	_, err := io.WriteString(w, C.GoString(chars))
+	return err
 }
 
 func testToScss(t *testing.T) {
@@ -41,7 +41,11 @@ body {
   font: 100% $font-stack;
   color: $primary-color; }
 `
-	if s := ToScss(file); s != e {
-		t.Errorf("got:\n%s\nwanted:\n%s", s, e)
+
+	var bytes bytes.Buffer
+	ToScss(file, &bytes)
+
+	if bytes.String() != e {
+		t.Errorf("got:\n%s\nwanted:\n%s", bytes.String(), e)
 	}
 }

--- a/context/toscss.go
+++ b/context/toscss.go
@@ -5,11 +5,8 @@ package context
 import "C"
 
 import (
-	"bytes"
 	"io"
 	"io/ioutil"
-	"os"
-	"testing"
 	"unsafe"
 )
 
@@ -27,21 +24,4 @@ func ToScss(r io.Reader, w io.Writer) error {
 	)
 	_, err := io.WriteString(w, C.GoString(chars))
 	return err
-}
-
-func testToScss(t *testing.T) {
-	file, err := os.Open("../test/whitespace/one.sass")
-	if err != nil {
-		t.Fatal(err)
-	}
-	e := `$font-stack:    Helvetica, sans-serif;
-$primary-color: #333;
-`
-
-	var bytes bytes.Buffer
-	ToScss(file, &bytes)
-
-	if bytes.String() != e {
-		t.Errorf("got:\n%s\nwanted:\n%s", bytes.String(), e)
-	}
 }

--- a/context/toscss.go
+++ b/context/toscss.go
@@ -1,0 +1,47 @@
+package context
+
+// #include <stdlib.h>
+// #include "sass2scss.h"
+import "C"
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+	"testing"
+	"unsafe"
+)
+
+// ToScss converts Sass to Scss with libsass sass2scss.h
+func ToScss(r io.Reader) string {
+	bs, _ := ioutil.ReadAll(r)
+	in := C.CString(string(bs))
+
+	defer C.free(unsafe.Pointer(in))
+
+	chars := C.sass2scss(
+		// FIXME: readers would be much more efficient
+		in,
+		// SASS2SCSS_PRETTIFY_1 Egyptian brackets
+		C.int(1),
+	)
+
+	return C.GoString(chars)
+}
+
+func testToScss(t *testing.T) {
+	file, err := os.Open("../test/whitespace/one.sass")
+	if err != nil {
+		t.Fatal(err)
+	}
+	e := `$font-stack:    Helvetica, sans-serif;
+$primary-color: #333;
+
+body {
+  font: 100% $font-stack;
+  color: $primary-color; }
+`
+	if s := ToScss(file); s != e {
+		t.Errorf("got:\n%s\nwanted:\n%s", s, e)
+	}
+}

--- a/context/toscss.go
+++ b/context/toscss.go
@@ -36,10 +36,6 @@ func testToScss(t *testing.T) {
 	}
 	e := `$font-stack:    Helvetica, sans-serif;
 $primary-color: #333;
-
-body {
-  font: 100% $font-stack;
-  color: $primary-color; }
 `
 
 	var bytes bytes.Buffer

--- a/context/toscss_test.go
+++ b/context/toscss_test.go
@@ -1,7 +1,52 @@
 package context
 
-import "testing"
+import (
+	"bytes"
+	"os"
+	"testing"
+)
 
 func TestToScss(t *testing.T) {
-	testToScss(t)
+	file, err := os.Open("../test/whitespace/one.sass")
+	if err != nil {
+		t.Fatal(err)
+	}
+	e := `$font-stack:    Helvetica, sans-serif;
+$primary-color: #333;
+`
+	var b bytes.Buffer
+	ToScss(file, &b)
+
+	if b.String() != e {
+		t.Errorf("got:\n%s\nwanted:\n%s", b.String(), e)
+	}
+
+	s := []byte(`=border-radius($radius)
+  -webkit-border-radius: $radius
+  -moz-border-radius:    $radius
+  -ms-border-radius:     $radius
+  border-radius:         $radius
+
+.box
+  +border-radius(10px)`)
+
+	var in bytes.Buffer
+	b.Reset()
+	in.Write(s)
+
+	ToScss(&in, &b)
+
+	e = `@mixin border-radius($radius) {
+  -webkit-border-radius: $radius;
+  -moz-border-radius:    $radius;
+  -ms-border-radius:     $radius;
+  border-radius:         $radius; }
+
+.box {
+  @include border-radius(10px); }
+`
+
+	if b.String() != e {
+		t.Errorf("got:\n%s\nwanted:\n%s", b.String(), e)
+	}
 }

--- a/context/toscss_test.go
+++ b/context/toscss_test.go
@@ -1,0 +1,7 @@
+package context
+
+import "testing"
+
+func TestToScss(t *testing.T) {
+	testToScss(t)
+}

--- a/filewatcher_test.go
+++ b/filewatcher_test.go
@@ -17,7 +17,7 @@ func TestPartialMap(t *testing.T) {
 		PartialMap: NewPartialMap(),
 	}
 
-	p.Start(fileReader("test/sass/import.scss"), "test/")
+	p.Start(fileReader("test/sass/import.scss"), "test/sass")
 
 	if e := 1; len(p.PartialMap.M) != e {
 		t.Errorf("got: %d, wanted: %d", len(p.PartialMap.M), e)

--- a/filewatcher_test.go
+++ b/filewatcher_test.go
@@ -17,7 +17,7 @@ func TestPartialMap(t *testing.T) {
 		PartialMap: NewPartialMap(),
 	}
 
-	p.Start(fileReader("test/sass/import.scss"), "test/sass")
+	p.Start(fileReader("test/sass/import.scss"), "test/")
 
 	if e := 1; len(p.PartialMap.M) != e {
 		t.Errorf("got: %d, wanted: %d", len(p.PartialMap.M), e)

--- a/import.go
+++ b/import.go
@@ -30,7 +30,6 @@ import (
 // {Dir{dir+file}}/{Base{file}}.sass
 func (p *Parser) ImportPath(dir, file string) (string, string, error) {
 	baseerr := ""
-
 	r, fpath, err := importPath(dir, file)
 	if err == nil {
 		p.PartialMap.AddRelation(p.MainFile, fpath)
@@ -45,22 +44,11 @@ func (p *Parser) ImportPath(dir, file string) (string, string, error) {
 	if strings.HasSuffix(err.Error(), "no such file or directory") {
 		// Look through the import path for the file
 		for _, lib := range p.Includes {
-			path, _ := filepath.Abs(lib + "/" + file)
-			pwd := filepath.Dir(path)
-			fpath = filepath.Join(pwd, "/_"+filepath.Base(path)+".scss")
-			contents, err := readSassBytes(fpath)
-			baseerr += fpath + "\n"
+			r, pwd, err := importPath(lib, file)
 			if err == nil {
 				p.PartialMap.AddRelation(p.MainFile, fpath)
-				return pwd, string(contents), nil
-			}
-			// Attempt invalid name lookup (no _)
-			fpath = filepath.Join(pwd, "/"+filepath.Base(path)+".scss")
-			contents, err = readSassBytes(fpath)
-			baseerr += fpath + "\n"
-			if err == nil {
-				p.PartialMap.AddRelation(p.MainFile, fpath)
-				return pwd, string(contents), nil
+				bs, _ := ioutil.ReadAll(r)
+				return pwd, string(bs), nil
 			}
 		}
 	}

--- a/import.go
+++ b/import.go
@@ -1,9 +1,13 @@
 package wellington
 
 import (
+	"bufio"
+	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -18,21 +22,38 @@ import (
 //
 // Paths are looked up in the following order:
 // {includepath}/_file.scss
+// {includePath}/_file.sass
 // {includepath}/file.scss
-// {Dir{dir+file}}/_{Base{file}}
-// {Dir{dir+file}}/{Base{file}}
+// {includePath}/file.sass
+// {Dir{dir+file}}/_{Base{file}}.scss
+// {Dir{dir+file}}/_{Base{file}}.sass
+// {Dir{dir+file}}/{Base{file}}.scss
+// {Dir{dir+file}}/{Base{file}}.sass
 func (p *Parser) ImportPath(dir, file string) (string, string, error) {
 	// fmt.Println("Importing: " + file)
 	baseerr := ""
 	//Load and retrieve all tokens from imported file
-	path, _ := filepath.Abs(fmt.Sprintf("%s/%s.scss", dir, file))
+	/*path, _ := filepath.Abs(fmt.Sprintf("%s/%s.scss", dir, file))
 	pwd := filepath.Dir(path)
 	// Sass put _ in front of imported files
 	fpath := filepath.Join(pwd, "/_"+filepath.Base(path))
-	contents, err := ioutil.ReadFile(fpath)
+	contents, err := readSassBytes(fpath)
 	if err == nil {
 		p.PartialMap.AddRelation(p.MainFile, fpath)
 		return pwd, string(contents), nil
+	}
+	// Try again without _, invalidish
+	fpath = filepath.Join(pwd, filepath.Base(path))
+	contents, err = readSassBytes(fpath)
+	if err == nil {
+		p.PartialMap.AddRelation(p.MainFile, fpath)
+		return pwd, string(contents), nil
+	}*/
+	r, fpath, err := importPath(dir, file)
+	if err == nil {
+		p.PartialMap.AddRelation(p.MainFile, fpath)
+		contents, _ := ioutil.ReadAll(r)
+		return filepath.Dir(fpath), string(contents), nil
 	}
 	baseerr += fpath + "\n"
 	if strings.HasSuffix(err.Error(), "no such file or directory") {
@@ -41,7 +62,7 @@ func (p *Parser) ImportPath(dir, file string) (string, string, error) {
 			path, _ := filepath.Abs(lib + "/" + file)
 			pwd := filepath.Dir(path)
 			fpath = filepath.Join(pwd, "/_"+filepath.Base(path)+".scss")
-			contents, err := ioutil.ReadFile(fpath)
+			contents, err := readSassBytes(fpath)
 			baseerr += fpath + "\n"
 			if err == nil {
 				p.PartialMap.AddRelation(p.MainFile, fpath)
@@ -49,7 +70,7 @@ func (p *Parser) ImportPath(dir, file string) (string, string, error) {
 			}
 			// Attempt invalid name lookup (no _)
 			fpath = filepath.Join(pwd, "/"+filepath.Base(path)+".scss")
-			contents, err = ioutil.ReadFile(fpath)
+			contents, err = readSassBytes(fpath)
 			baseerr += fpath + "\n"
 			if err == nil {
 				p.PartialMap.AddRelation(p.MainFile, fpath)
@@ -60,11 +81,87 @@ func (p *Parser) ImportPath(dir, file string) (string, string, error) {
 	// Ignore failures on compass
 	re := regexp.MustCompile("compass\\/?")
 	if re.Match([]byte(file)) {
-		return pwd, string(contents), nil //errors.New("compass")
+		return filepath.Dir(fpath), "", nil //errors.New("compass")
 	}
 	if file == "images" {
-		return pwd, string(contents), nil
+		return filepath.Dir(fpath), "", nil
 	}
-	return pwd, string(contents), errors.New("Could not import: " +
+	return filepath.Dir(fpath), "", errors.New("Could not import: " +
 		file + "\nTried:\n" + baseerr)
+}
+
+// Attempt _{}.scss, _{}.sass, {}.scss, {}.sass paths and return
+// reader if found
+func importPath(dir, file string) (io.Reader, string, error) {
+	spath, _ := filepath.Abs(dir + "/" + file)
+	pwd := filepath.Dir(spath)
+	base := filepath.Base(spath)
+
+	fpath := filepath.Join(pwd, "_"+base+".scss")
+	if r, err := readSass(fpath); err == nil {
+		return r, fpath, err
+	}
+
+	fpath = filepath.Join(pwd, "_"+base+".sass")
+	if r, err := readSass(fpath); err == nil {
+		return r, fpath, err
+	}
+
+	fpath = filepath.Join(pwd, base+".scss")
+	if r, err := readSass(fpath); err == nil {
+		return r, fpath, err
+	}
+
+	fpath = filepath.Join(pwd, base+".sass")
+	if r, err := readSass(fpath); err == nil {
+		return r, fpath, err
+	}
+
+	return nil, "", errors.New("Unable to import path:" + dir + " " + file)
+}
+
+func readSassBytes(path string) ([]byte, error) {
+	reader, err := readSass(path)
+	if err != nil {
+		return nil, err
+	}
+	return ioutil.ReadAll(reader)
+}
+
+// readSass retrives a file from path. If found, it converts Sass
+// to Scss or returns found Scss;
+func readSass(path string) (io.Reader, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	tr := io.TeeReader(file, &buf)
+
+	fmt.Println("Sass?", IsSass(bufio.NewReader(tr)))
+	mr := io.MultiReader(&buf, file)
+	return mr, nil
+}
+
+// IsSass determines if the given reader is Sass (not Scss).
+// This is predicted by the presence of semicolons
+func IsSass(r *bufio.Reader) bool {
+	for {
+		line, err := r.ReadString('\n')
+		clean := strings.TrimSpace(line)
+		// Errors, empty file probably
+		if err != nil {
+			return false
+		}
+		if strings.HasSuffix(clean, "{") ||
+			strings.HasSuffix(clean, "}") {
+			continue
+		}
+		if strings.HasSuffix(clean, ";") {
+			return false
+		}
+		// Probably Sass, say so
+		return true
+	}
 }

--- a/import.go
+++ b/import.go
@@ -41,7 +41,7 @@ func (p *Parser) ImportPath(dir, file string) (string, string, error) {
 		rel = "./"
 	}
 	baseerr += rel + "\n"
-	if strings.HasSuffix(err.Error(), "no such file or directory") {
+	if os.IsNotExist(err) {
 		// Look through the import path for the file
 		for _, lib := range p.Includes {
 			r, pwd, err := importPath(lib, file)
@@ -77,6 +77,7 @@ func importPath(dir, file string) (io.Reader, string, error) {
 	if r, err := readSass(fpath); err == nil {
 		return r, fpath, err
 	}
+
 	fpath = filepath.Join(pwd, base+".scss")
 	if r, err := readSass(fpath); err == nil {
 		return r, fpath, err
@@ -92,7 +93,7 @@ func importPath(dir, file string) (io.Reader, string, error) {
 		return r, fpath, err
 	}
 
-	return nil, pwd, errors.New("Unable to import path:" + dir + " " + file)
+	return nil, pwd, os.ErrNotExist
 }
 
 func readSassBytes(path string) ([]byte, error) {

--- a/import.go
+++ b/import.go
@@ -125,12 +125,18 @@ func ToScssReader(r io.Reader) (io.Reader, error) {
 	tr := io.TeeReader(r, &buf)
 
 	if IsSass(&tr) {
-		pr, w := io.Pipe()
-		go func() {
-			context.ToScss(io.MultiReader(&buf, r), w)
-			w.Close()
-		}()
-		return pr, nil
+
+		//This code causes race conditions, buffer until problem resolved
+		// pr, w := io.Pipe()
+		// go func(r io.Reader, w *io.PipeWriter, buf bytes.Buffer) {
+		// 	context.ToScss(io.MultiReader(&buf, r), w)
+		// 	w.Close()
+		// }(r, w, buf)
+		// return pr, nil
+
+		var ibuf bytes.Buffer
+		context.ToScss(io.MultiReader(&buf, r), &ibuf)
+		return &ibuf, nil
 	}
 	mr := io.MultiReader(&buf, r)
 

--- a/import_test.go
+++ b/import_test.go
@@ -72,7 +72,17 @@ func TestImportSass(t *testing.T) {
 
 	}
 
-	t.Error(res)
+	e := `$font-stack:    Helvetica, sans-serif;
+$primary-color: #333;
+
+body {
+  font: 100% $font-stack;
+  color: $primary-color; }
+`
+
+	if e != res {
+		t.Errorf("got:\n%s\nwanted:\n%s", res, e)
+	}
 
 	// Importer
 	//dir, file := "test/whitespace", "import"

--- a/import_test.go
+++ b/import_test.go
@@ -1,7 +1,6 @@
 package wellington
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -73,7 +72,7 @@ func TestImportSass(t *testing.T) {
 
 	}
 
-	fmt.Println(res)
+	t.Error(res)
 
 	// Importer
 	//dir, file := "test/whitespace", "import"

--- a/import_test.go
+++ b/import_test.go
@@ -1,6 +1,7 @@
 package wellington
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -57,4 +58,22 @@ func TestMissingImport(t *testing.T) {
 		"/test/_notafile.scss\n"; rel != e {
 		t.Errorf("Error message invalid expected:%s\nwas:%s", e, err.Error())
 	}
+}
+
+func TestImportSass(t *testing.T) {
+	p := NewParser()
+	dir, file := "test/whitespace", "one"
+
+	_, res, err := p.ImportPath(dir, file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res != "" {
+
+	}
+
+	fmt.Println(res)
+
+	// Importer
+	//dir, file := "test/whitespace", "import"
 }

--- a/import_test.go
+++ b/import_test.go
@@ -55,8 +55,9 @@ func TestMissingImport(t *testing.T) {
 
 	rel := strings.Replace(err.Error(), os.Getenv("PWD"), "", 1)
 	if e := "Could not import: notafile\nTried:\n" +
-		"/test/_notafile.scss\n"; rel != e {
-		t.Errorf("Error message invalid expected:%s\nwas:%s", e, err.Error())
+		"./\n"; rel != e {
+		t.Errorf("Error message invalid\nexpected: %s\nwas: %s",
+			e, err.Error())
 	}
 }
 

--- a/import_test.go
+++ b/import_test.go
@@ -18,13 +18,13 @@ func TestImportPath(t *testing.T) {
 	}
 
 	if res != string(contents) {
-		t.Errorf("Contents did not match expected:%s\nwas:%s",
+		t.Errorf("Contents did not match expected:\n%s\nwas:\n%s",
 			string(contents), res)
 	}
 
 	rel := strings.Replace(path, os.Getenv("PWD"), "", 1)
 	if e := "/test/sass"; e != rel {
-		t.Errorf("Invalid path expected:%s\nwas:%s", e, rel)
+		t.Errorf("Invalid path expected:\n%s\nwas:\n%s", e, rel)
 	}
 
 	p.Includes = []string{"test"}

--- a/import_test.go
+++ b/import_test.go
@@ -62,7 +62,7 @@ func TestMissingImport(t *testing.T) {
 
 func TestImportSass(t *testing.T) {
 	p := NewParser()
-	dir, file := "test/whitespace", "one"
+	dir, file := "test/whitespace", "two"
 
 	_, res, err := p.ImportPath(dir, file)
 	if err != nil {
@@ -72,12 +72,19 @@ func TestImportSass(t *testing.T) {
 
 	}
 
-	e := `$font-stack:    Helvetica, sans-serif;
-$primary-color: #333;
+	e := `nav {
+  ul {
+    margin: 0;
+    padding: 0;
+    list-style: none; }
 
-body {
-  font: 100% $font-stack;
-  color: $primary-color; }
+  li {
+    display: inline-block; }
+
+  a {
+    display: block;
+    padding: 6px 12px;
+    text-decoration: none; } }
 `
 
 	if e != res {

--- a/parser.go
+++ b/parser.go
@@ -2,6 +2,7 @@ package wellington
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -61,7 +62,26 @@ func NewParser() *Parser {
 // Start creates a map of all variables and sprites
 // (created via sprite-map calls).
 // TODO: Remove pkgdir, it can be put on Parser
-func (p *Parser) Start(in io.Reader, pkgdir string) ([]byte, error) {
+func (p *Parser) Start(r io.Reader, pkgdir string) ([]byte, error) {
+
+	if r == nil {
+		return []byte{}, errors.New("input is empty")
+	}
+
+	var in io.Reader
+	var err error
+	var teebuf bytes.Buffer
+
+	tr := io.TeeReader(r, &teebuf)
+	if IsSass(&tr) {
+		rr, err := ToScssReader(io.MultiReader(&teebuf, r))
+		if err != nil {
+			return nil, err
+		}
+		in = rr
+	} else {
+		in = io.MultiReader(&teebuf, r)
+	}
 	p.Line = make(map[int]string)
 
 	// Setup paths
@@ -78,7 +98,7 @@ func (p *Parser) Start(in io.Reader, pkgdir string) ([]byte, error) {
 	if in == nil {
 		return []byte{}, fmt.Errorf("input is empty")
 	}
-	_, err := buf.ReadFrom(in)
+	_, err = buf.ReadFrom(in)
 	if err != nil {
 		return []byte{}, err
 	}
@@ -210,6 +230,7 @@ func (p *Parser) GetItems(pwd, filename, input string) ([]lexer.Item, string, er
 				if err != nil {
 					return nil, "", err
 				}
+
 				//Eat the semicolon
 				item := lex.Next()
 				if item.Type != token.SEMIC {

--- a/parser.go
+++ b/parser.go
@@ -70,18 +70,13 @@ func (p *Parser) Start(r io.Reader, pkgdir string) ([]byte, error) {
 
 	var in io.Reader
 	var err error
-	var teebuf bytes.Buffer
 
-	tr := io.TeeReader(r, &teebuf)
-	if IsSass(&tr) {
-		rr, err := ToScssReader(io.MultiReader(&teebuf, r))
-		if err != nil {
-			return nil, err
-		}
-		in = rr
-	} else {
-		in = io.MultiReader(&teebuf, r)
+	in, err = ToScssReader(r)
+
+	if err != nil {
+		return nil, err
 	}
+
 	p.Line = make(map[int]string)
 
 	// Setup paths

--- a/spec_test.go
+++ b/spec_test.go
@@ -1,0 +1,35 @@
+package wellington
+
+import "testing"
+
+func TestProcessSass(t *testing.T) {
+
+	p := NewParser()
+	p.Includes = []string{"test/whitespace"}
+
+	in := fileReader("test/whitespace/import.sass")
+
+	bs, err := p.Start(in, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e := `@mixin sprite-dimensions($map, $name) {
+  $file: sprite-file($map, $name);
+  height: image-height($file);
+  width: image-width($file);
+}
+
+$font-stack:    Helvetica, sans-serif;
+$primary-color: #333;
+
+
+body {
+  font: 100% $font-stack;
+  background-color: $primary-color; }
+`
+
+	if e != string(bs) {
+		t.Errorf("got:\n%s\nwanted:\n%s", string(bs), e)
+	}
+}

--- a/spec_test.go
+++ b/spec_test.go
@@ -2,7 +2,7 @@ package wellington
 
 import "testing"
 
-func TestProcessSass(t *testing.T) {
+func TestSassToScss(t *testing.T) {
 
 	p := NewParser()
 	p.Includes = []string{"test/whitespace"}
@@ -27,6 +27,29 @@ $primary-color: #333;
 body {
   font: 100% $font-stack;
   background-color: $primary-color; }
+`
+
+	if e != string(bs) {
+		t.Errorf("got:\n%s\nwanted:\n%s", string(bs), e)
+	}
+
+	bs, err = p.Start(fileReader("test/whitespace/base.sass"), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e = `@mixin sprite-dimensions($map, $name) {
+  $file: sprite-file($map, $name);
+  height: image-height($file);
+  width: image-width($file);
+}
+
+html,
+body,
+ul,
+ol {
+  margin:  0;
+  padding: 0; }
 `
 
 	if e != string(bs) {

--- a/test/whitespace/base.sass
+++ b/test/whitespace/base.sass
@@ -1,0 +1,8 @@
+// _reset.sass
+
+html,
+body,
+ul,
+ol
+  margin:  0
+  padding: 0

--- a/test/whitespace/import.sass
+++ b/test/whitespace/import.sass
@@ -1,0 +1,7 @@
+// base.sass
+
+@import reset
+
+body
+  font: 100% Helvetica, sans-serif
+  background-color: #efefef

--- a/test/whitespace/import.sass
+++ b/test/whitespace/import.sass
@@ -1,7 +1,8 @@
 // base.sass
 
-@import reset
+@import one
+//@import two
 
 body
-  font: 100% Helvetica, sans-serif
-  background-color: #efefef
+  font: 100% $font-stack
+  background-color: $primary-color

--- a/test/whitespace/one.sass
+++ b/test/whitespace/one.sass
@@ -1,0 +1,6 @@
+$font-stack:    Helvetica, sans-serif
+$primary-color: #333
+
+body
+  font: 100% $font-stack
+  color: $primary-color

--- a/test/whitespace/one.sass
+++ b/test/whitespace/one.sass
@@ -1,6 +1,2 @@
 $font-stack:    Helvetica, sans-serif
 $primary-color: #333
-
-body
-  font: 100% $font-stack
-  color: $primary-color

--- a/test/whitespace/two.sass
+++ b/test/whitespace/two.sass
@@ -1,0 +1,13 @@
+nav
+  ul
+    margin: 0
+    padding: 0
+    list-style: none
+
+  li
+    display: inline-block
+
+  a
+    display: block
+    padding: 6px 12px
+    text-decoration: none


### PR DESCRIPTION
sass syntax uses meaningful whitespace to distinguish the normal semicolons and brackets. There's a number of obstacles to supporting this

- libsass can't distinguish between sass/scss in the data compiler
- wellington supports a number of import methods, so looking at file extensions will not always be an option
- wellington may only look for scss files right now

Solutions
- check file extension
- lexer could profile the input stream looking for the presence of `{ } ;`
- parser passes sass input to `sass2scss` upon determinaton that the syntax present is not `.scss`