### PR TITLE
Importer

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -52,7 +52,7 @@ type Context struct {
 	// is done with them
 	Cookies []Cookie
 
-	Imports []*C.struct_Sass_Import
+	Imports []Import
 	// Used for callbacks to retrieve sprite information, etc.
 	Imgs, Sprites spritewell.SafeImageMap
 	// Special variable for debugging bad parsing
@@ -149,7 +149,7 @@ func (ctx *Context) Init(dc *C.struct_Sass_Data_Context) *C.struct_Sass_Options 
 		gofns[i] = fn
 	}
 
-	SetImporter(opts)
+	ctx.SetImporter(opts)
 
 	C.sass_option_set_c_functions(opts, (C.Sass_C_Function_List)(unsafe.Pointer(&gofns[0])))
 	C.sass_option_set_precision(opts, prec)

--- a/context/context.go
+++ b/context/context.go
@@ -185,26 +185,6 @@ func (ctx *Context) Compile(in io.Reader, out io.Writer) error {
 	C.sass_data_context_set_options(dc, opts)
 	cc := C.sass_data_context_get_context(dc)
 	compiler := C.sass_make_data_compiler(dc)
-	// if len(ctx.Imports) > 0 {
-	// 	for _, imp := range ctx.Imports {
-	// 		fmt.Printf("% #v\n", imp)
-	// 	}
-
-	// 	C.sass_option_set_importer(opts,
-	// 		(*C.struct_Sass_C_Import_Descriptor)(
-	// 			unsafe.Pointer(ctx.Imports[0])))
-
-	// 	imps := C.sass_option_get_importer(opts)
-	// 	hdr := reflect.SliceHeader{
-	// 		Data: uintptr(unsafe.Pointer(imps)),
-	// 		Len:  len(ctx.Imports), Cap: len(ctx.Imports),
-	// 	}
-
-	// 	impss := *(*[]SassImport)(unsafe.Pointer(&hdr))
-	// 	for _, imp := range impss {
-	// 		fmt.Printf(">> % #v\n", imp)
-	// 	}
-	// }
 
 	C.sass_compiler_parse(compiler)
 	C.sass_compiler_execute(compiler)
@@ -231,9 +211,8 @@ func (ctx *Context) Compile(in io.Reader, out io.Writer) error {
 				out += fmt.Sprintf("%s\n", string(lines[i+ctx.Errors.Line]))
 			}
 		}
-
 		// TODO: this is weird, make something more idiomatic
-		return fmt.Errorf(ctx.error() + "\n" + out)
+		return errors.New(ctx.error() + "\n" + out)
 	}
 
 	return nil

--- a/context/context.go
+++ b/context/context.go
@@ -50,6 +50,7 @@ type Context struct {
 	// is done with them
 	Cookies []Cookie
 
+	Imports []*ImportCallback
 	// Used for callbacks to retrieve sprite information, etc.
 	Imgs, Sprites spritewell.SafeImageMap
 	// Special variable for debugging bad parsing
@@ -98,6 +99,10 @@ func (ctx *Context) Init(dc *C.struct_Sass_Data_Context) *C.struct_Sass_Options 
 
 	opts := C.sass_data_context_get_options(dc)
 
+	if len(ctx.Imports) > 0 {
+		C.sass_option_set_importer(opts,
+			(*C.struct_Sass_C_Import_Descriptor)(unsafe.Pointer(&ctx.Imports[0])))
+	}
 	defer func() {
 		C.free(unsafe.Pointer(imgpath))
 		// C.free(unsafe.Pointer(cc))

--- a/context/context.go
+++ b/context/context.go
@@ -1,8 +1,6 @@
 package context
 
 // #include <stdlib.h>
-// #include <stdio.h>
-// #include "sass_functions.h"
 // #include "sass_context.h"
 //
 // extern union Sass_Value* GoBridge( union Sass_Value* s_args, void* cookie);
@@ -10,12 +8,6 @@ package context
 //     return GoBridge(s_args, cookie);
 // }
 //
-// struct Sass_Import** SassImporter(const char* url, const char* prev, void* cookie)
-// {
-//   printf("sass_importer\n");
-//   struct Sass_Import** list = sass_make_import_list(2);
-//   return list;
-// }
 //
 import "C"
 
@@ -157,6 +149,8 @@ func (ctx *Context) Init(dc *C.struct_Sass_Data_Context) *C.struct_Sass_Options 
 		gofns[i] = fn
 	}
 
+	SetImporter(opts)
+
 	C.sass_option_set_c_functions(opts, (C.Sass_C_Function_List)(unsafe.Pointer(&gofns[0])))
 	C.sass_option_set_precision(opts, prec)
 	C.sass_option_set_source_comments(opts, cmt)
@@ -184,16 +178,13 @@ func (ctx *Context) Compile(in io.Reader, out io.Writer) error {
 	defer C.sass_delete_data_context(dc)
 
 	opts := ctx.Init(dc)
+
 	// TODO: Manually free options memory without throwing
 	// malloc errors
 	// defer C.free(unsafe.Pointer(opts))
 	C.sass_data_context_set_options(dc, opts)
 	cc := C.sass_data_context_get_context(dc)
 	compiler := C.sass_make_data_compiler(dc)
-	var v interface{}
-	impCallback := C.sass_make_importer(C.Sass_C_Import_Fn(C.SassImporter),
-		unsafe.Pointer(&v))
-	C.sass_option_set_importer(opts, impCallback)
 	// if len(ctx.Imports) > 0 {
 	// 	for _, imp := range ctx.Imports {
 	// 		fmt.Printf("% #v\n", imp)

--- a/context/importer.go
+++ b/context/importer.go
@@ -22,9 +22,14 @@ func testSassImport(t *testing.T) {
 	list[1] = sass_make_import_entry("http://www.example.com", strdup(remote), 0);
 	return list;*/
 	var entries []*C.struct_Sass_Import
-	entry := C.sass_make_import_entry(C.CString("a"), C.CString("a { color: red; }"), C.CString(""))
+	entry := C.sass_make_import_entry(
+		C.CString("a"),
+		C.CString("a { color: red; }"),
+		C.CString(""))
 	entries = append(entries, entry)
 	path := C.sass_import_get_path(entries[0])
+	fmt.Println(C.GoString(path))
+	path = C.sass_import_get_source(entries[0])
 	fmt.Println(C.GoString(path))
 
 	//fmt.Println(entry.)

--- a/context/importer.go
+++ b/context/importer.go
@@ -1,0 +1,31 @@
+package context
+
+// #include "sass_context.h"
+// #include "sass_functions.h"
+import "C"
+import (
+	"fmt"
+	"testing"
+)
+
+// SassImport ...
+type SassImport C.struct_Sass_Import
+
+// ImportCallback ...
+type ImportCallback C.Sass_C_Import_Callback
+
+func testSassImport(t *testing.T) {
+	/*struct Sass_Import** list = sass_make_import_list(2);
+	const char* local = "local { color: green; }";
+	const char* remote = "remote { color: red; }";
+	list[0] = sass_make_import_entry("/tmp/styles.scss", strdup(local), 0);
+	list[1] = sass_make_import_entry("http://www.example.com", strdup(remote), 0);
+	return list;*/
+	var entries []*C.struct_Sass_Import
+	entry := C.sass_make_import_entry(C.CString("a"), C.CString("a { color: red; }"), C.CString(""))
+	entries = append(entries, entry)
+	path := C.sass_import_get_path(entries[0])
+	fmt.Println(C.GoString(path))
+
+	//fmt.Println(entry.)
+}

--- a/context/importer.go
+++ b/context/importer.go
@@ -1,12 +1,17 @@
 package context
 
-// #include "sass_context.h"
+// #include <stdlib.h>
+// #include <stdio.h>
 // #include "sass_functions.h"
+// #include "sass_context.h"
+//
+//
 import "C"
 import (
+	"bytes"
 	"fmt"
+	"path/filepath"
 	"testing"
-	"unsafe"
 )
 
 // SassImport ...
@@ -15,9 +20,40 @@ type SassImport C.struct_Sass_Import
 // ImportCallback ...
 type ImportCallback C.Sass_C_Import_Callback
 
+// AddImport ...
+func (ctx *Context) AddImport(name string, contents string) {
+	path := C.CString(name)
+	cnts := C.CString(contents)
+	empty := C.CString("")
+	//defer C.free(unsafe.Pointer(path))
+	//defer C.free(unsafe.Pointer(cnts))
+	//defer C.free(unsafe.Pointer(empty))
+	//defer C.free(unsafe.Pointer(abss))
+	abs, _ := filepath.Abs(name)
+	abss := C.CString(abs)
+	entry := C.sass_make_import(path, abss, cnts, empty)
+	//ctx.Imports = append(ctx.Imports, (*SassImport)(entry))
+	ctx.Imports = append(ctx.Imports, entry)
+}
+
 func testSassImport(t *testing.T) {
 
-	var entries []*SassImport
+	in := bytes.NewBufferString(`@import "a";`)
+
+	var out bytes.Buffer
+	ctx := Context{}
+	ctx.AddImport("a", "a { color: blue; }")
+	err := ctx.Compile(in, &out)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	src := C.sass_import_get_source((*C.struct_Sass_Import)(ctx.Imports[0]))
+	fmt.Printf("%s\n", C.GoString(src))
+
+	fmt.Println(out.String())
+
+	/*var entries []*SassImport
 	entry := C.sass_make_import_entry(
 		C.CString("a"),
 		C.CString("a { color: red; }"),
@@ -26,6 +62,6 @@ func testSassImport(t *testing.T) {
 	path := C.sass_import_get_path((*C.struct_Sass_Import)(unsafe.Pointer(&entries[0])))
 	fmt.Println(C.GoString(path))
 	path = C.sass_import_get_source((*C.struct_Sass_Import)(entries[0]))
-	fmt.Println(C.GoString(path))
+	fmt.Println(C.GoString(path))*/
 
 }

--- a/context/importer.go
+++ b/context/importer.go
@@ -16,12 +16,7 @@ type SassImport C.struct_Sass_Import
 type ImportCallback C.Sass_C_Import_Callback
 
 func testSassImport(t *testing.T) {
-	/*struct Sass_Import** list = sass_make_import_list(2);
-	const char* local = "local { color: green; }";
-	const char* remote = "remote { color: red; }";
-	list[0] = sass_make_import_entry("/tmp/styles.scss", strdup(local), 0);
-	list[1] = sass_make_import_entry("http://www.example.com", strdup(remote), 0);
-	return list;*/
+
 	var entries []*SassImport
 	entry := C.sass_make_import_entry(
 		C.CString("a"),
@@ -33,5 +28,4 @@ func testSassImport(t *testing.T) {
 	path = C.sass_import_get_source((*C.struct_Sass_Import)(entries[0]))
 	fmt.Println(C.GoString(path))
 
-	//fmt.Println(entry.)
 }

--- a/context/importer.go
+++ b/context/importer.go
@@ -6,6 +6,7 @@ import "C"
 import (
 	"fmt"
 	"testing"
+	"unsafe"
 )
 
 // SassImport ...
@@ -21,15 +22,15 @@ func testSassImport(t *testing.T) {
 	list[0] = sass_make_import_entry("/tmp/styles.scss", strdup(local), 0);
 	list[1] = sass_make_import_entry("http://www.example.com", strdup(remote), 0);
 	return list;*/
-	var entries []*C.struct_Sass_Import
+	var entries []*SassImport
 	entry := C.sass_make_import_entry(
 		C.CString("a"),
 		C.CString("a { color: red; }"),
 		C.CString(""))
-	entries = append(entries, entry)
-	path := C.sass_import_get_path(entries[0])
+	entries = append(entries, (*SassImport)(entry))
+	path := C.sass_import_get_path((*C.struct_Sass_Import)(unsafe.Pointer(&entries[0])))
 	fmt.Println(C.GoString(path))
-	path = C.sass_import_get_source(entries[0])
+	path = C.sass_import_get_source((*C.struct_Sass_Import)(entries[0]))
 	fmt.Println(C.GoString(path))
 
 	//fmt.Println(entry.)

--- a/context/importer_test.go
+++ b/context/importer_test.go
@@ -48,3 +48,34 @@ b {
 	}
 
 }
+
+func TestSassImporter_nested(t *testing.T) {
+	in := bytes.NewBufferString(`@import "branch";
+div.branch {
+  @extend %branch;
+  div.leaf {
+    @extend %leaf;
+  }
+}`)
+
+	var out bytes.Buffer
+	ctx := Context{}
+
+	ctx.AddImport("branch", `@import "leaf";
+%branch { color: brown; }`)
+	ctx.AddImport("leaf", "%leaf { color: green; }")
+	err := ctx.Compile(in, &out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e := `div.branch div.leaf {
+  color: green; }
+
+div.branch {
+  color: brown; }
+
+`
+	if e != out.String() {
+		t.Fatalf("got:\n%s\nwanted:\n%s", out.String(), e)
+	}
+}

--- a/context/importer_test.go
+++ b/context/importer_test.go
@@ -1,7 +1,50 @@
 package context
 
-import "testing"
+import (
+	"bytes"
+	"testing"
+)
 
-func TestSassImport(t *testing.T) {
-	testSassImport(t)
+func TestSassImport_single(t *testing.T) {
+	in := bytes.NewBufferString(`@import "a";`)
+
+	var out bytes.Buffer
+	ctx := Context{}
+	ctx.AddImport("a", "a { color: blue; }")
+	err := ctx.Compile(in, &out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e := `a {
+  color: blue; }
+`
+	if e != out.String() {
+		t.Fatalf("got:\n%s\nwanted:\n%s", out.String(), e)
+	}
+
+}
+
+func TestSassImport_multi(t *testing.T) {
+	in := bytes.NewBufferString(`@import "a";
+@import "b";`)
+
+	var out bytes.Buffer
+	ctx := Context{}
+	ctx.AddImport("a", "a { color: blue; }")
+	ctx.AddImport("b", "b { font-weight: bold; }")
+	err := ctx.Compile(in, &out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e := `a {
+  color: blue; }
+
+b {
+  font-weight: bold; }
+`
+
+	if e != out.String() {
+		t.Fatalf("got:\n%s\nwanted:\n%s", out.String(), e)
+	}
+
 }

--- a/context/importer_test.go
+++ b/context/importer_test.go
@@ -2,6 +2,7 @@ package context
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 )
 
@@ -49,7 +50,30 @@ b {
 
 }
 
-func TestSassImporter_nested(t *testing.T) {
+func TestSassImporter_placeholder(t *testing.T) {
+	in := bytes.NewBufferString(`@import "branch";
+div.branch {
+  @extend %branch;
+}`)
+
+	var out bytes.Buffer
+	ctx := Context{}
+
+	ctx.AddImport("branch", `%branch { color: brown; }`)
+	err := ctx.Compile(in, &out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e := `div.branch {
+  color: brown; }
+
+`
+	if e != out.String() {
+		t.Fatalf("got:\n%s\nwanted:\n%s", out.String(), e)
+	}
+}
+
+func TestSassImporter_nested_placeholder(t *testing.T) {
 	in := bytes.NewBufferString(`@import "branch";
 div.branch {
   @extend %branch;
@@ -78,4 +102,58 @@ div.branch {
 	if e != out.String() {
 		t.Fatalf("got:\n%s\nwanted:\n%s", out.String(), e)
 	}
+}
+
+func TestSassImporter_invalidimport(t *testing.T) {
+	in := bytes.NewBufferString(`@import "branch";
+div.branch {
+  @extend %branch;
+  div.leaf {
+    @extend %leaf;
+  }
+}`)
+
+	var out bytes.Buffer
+	ctx := Context{}
+
+	err := ctx.Compile(in, &out)
+	if err == nil {
+		t.Fatal("No error thrown for missing import")
+	}
+	e := `Error > stdin:1
+file to import not found or unreadable: branch
+Current dir: ` + `
+@import "branch";
+div.branch {
+  @extend %branch;
+  div.leaf {
+    @extend %leaf;
+  }
+}
+`
+	if e != err.Error() {
+		t.Fatalf("got:\n%s\nwanted:\n%s",
+			strings.Replace(err.Error(), " ", "*", -1),
+			strings.Replace(e, " ", "*", -1))
+	}
+
+}
+
+func TestSassImporter_notfound(t *testing.T) {
+	t.Skip("Skip this test for now")
+	in := bytes.NewBufferString(`@import "branch";
+div.branch {
+  @extend %branch;
+  div.leaf {
+    @extend %leaf;
+  }
+}`)
+
+	var out bytes.Buffer
+	ctx := Context{}
+	ctx.AddImport("nope", `@import "leaf";
+%branch { color: brown; }`)
+	err := ctx.Compile(in, &out)
+
+	t.Error(err)
 }

--- a/context/importer_test.go
+++ b/context/importer_test.go
@@ -1,0 +1,7 @@
+package context
+
+import "testing"
+
+func TestSassImport(t *testing.T) {
+	testSassImport(t)
+}

--- a/test/nested/_branch.scss
+++ b/test/nested/_branch.scss
@@ -1,0 +1,2 @@
+@import "leaf";
+%branch { color: brown; }

--- a/test/nested/_leaf.scss
+++ b/test/nested/_leaf.scss
@@ -1,0 +1,1 @@
+%leaf { color: green; }

--- a/test/nested/tree.scss
+++ b/test/nested/tree.scss
@@ -1,0 +1,7 @@
+@import "branch";
+div.branch {
+  @extend %branch;
+  div.leaf {
+    @extend %leaf;
+  }
+}


### PR DESCRIPTION
Adds support for custom importers. This is not ready for primetime as failure conditions result in runtime errors in libsass. It is an interesting concept and would allow robust line number, errors, and source map generation for tools integrating libsass.