### PR TITLE
exit with proper exit code on sass error

### DIFF
--- a/wt/main.go
+++ b/wt/main.go
@@ -206,6 +206,7 @@ func main() {
 		err := wt.LoadAndBuild(f, gba, pMap)
 		if err != nil {
 			log.Println(err)
+			os.Exit(1)
 		}
 	}
 


### PR DESCRIPTION
This should allow us to exit with the catch-all shell errorcode of 1, which will stop the build.