### PR TITLE
share folder into container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ container-build:
 	- mkdir build
 	- rm profile.cov
 	docker build -t wt-build .
-	docker run -v $(PWD)/build:/tmp -e EUID=$(shell id -u) -e EGID=$(shell id -g) wt-build make copyout
+	docker run -v $(GOPATH)/pkg:/usr/pkg -v $(PWD)/build:/tmp -e EUID=$(shell id -u) -e EGID=$(shell id -g) wt-build make copyout
 
 build: container-build
 	cp Dockerfile.scratch build/Dockerfile


### PR DESCRIPTION
By sharing the pkg directory from libsass64, it should be possible to have packages precompiled in the container.

fixes #91 