### PR TITLE
start work for supporting passing directories as arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.#*
 .libsass_version_*
 node_modules
 .DS_Store

--- a/Dockerfile.scratch
+++ b/Dockerfile.scratch
@@ -11,4 +11,4 @@ EXPOSE 12345
 VOLUME "/data"
 WORKDIR /data
 
-CMD wt serve -p /data --images-dir /data/img -b /data/build --gen /data/build/img
+CMD wt serve --sass-dir /data/sass --images-dir /data/img -b /data/build --gen /data/build/img

--- a/build.go
+++ b/build.go
@@ -16,7 +16,19 @@ var inputFileTypes = []string{".scss", ".sass"}
 
 // LoadAndBuild kicks off parser and compiling
 // TODO: make this function testable
-func LoadAndBuild(sassFile string, gba BuildArgs, partialMap *SafePartialMap) error {
+func LoadAndBuild(path string, gba BuildArgs, pMap *SafePartialMap) error {
+	var files []string
+	// file detected!
+	if filepath.Dir(path) != path {
+		return loadAndBuild(path, gba, pMap)
+	}
+	_ = files
+	// Expand directory to all non-partial sass files
+
+	return nil
+}
+
+func loadAndBuild(sassFile string, gba BuildArgs, partialMap *SafePartialMap) error {
 
 	// If no imagedir specified, assume relative to the input file
 	if gba.Dir == "" {

--- a/build.go
+++ b/build.go
@@ -13,6 +13,9 @@ import (
 	libsass "github.com/wellington/go-libsass"
 )
 
+// BuildOptions holds a set of read only arguments to the builder.
+// Channels from this are used to communicate between the workers
+// and loaders executing builds.
 type BuildOptions struct {
 	wg      sync.WaitGroup
 	closing chan struct{}
@@ -29,6 +32,7 @@ type BuildOptions struct {
 	PartialMap *SafePartialMap
 }
 
+// NewBuild accepts arguments to reate a new Builder
 func NewBuild(paths []string, args *BuildArgs, pMap *SafePartialMap, async bool) *BuildOptions {
 	return &BuildOptions{
 		done:   make(chan error),

--- a/build.go
+++ b/build.go
@@ -13,6 +13,8 @@ import (
 	libsass "github.com/wellington/go-libsass"
 )
 
+var testch chan struct{}
+
 // BuildOptions holds a set of read only arguments to the builder.
 // Channels from this are used to communicate between the workers
 // and loaders executing builds.
@@ -225,7 +227,11 @@ func loadAndBuild(sassFile string, gba *BuildArgs, partialMap *SafePartialMap, o
 	}
 	out.Close()
 	go func(sassFile string) {
-		fmt.Printf("Rebuilt: %s\n", sassFile)
+		select {
+		case <-testch:
+		default:
+			fmt.Printf("Rebuilt: %s\n", sassFile)
+		}
 	}(sassFile)
 	return nil
 }

--- a/build.go
+++ b/build.go
@@ -137,7 +137,8 @@ func (b *BuildArgs) getOut(path string) (io.WriteCloser, string, error) {
 	return out, fout, nil
 }
 
-// LoadAndBuild kicks off parser and compiling
+// LoadAndBuild kicks off parser and compiling. It expands directories
+// to recursively locate Sass files
 // TODO: make this function testable
 func LoadAndBuild(path string, gba *BuildArgs, pMap *SafePartialMap) error {
 	var files []string

--- a/build_test.go
+++ b/build_test.go
@@ -83,7 +83,7 @@ func TestNewBuild_dir(t *testing.T) {
 
 }
 
-func ExampleBuild() {
+func ExampleLoadAndBuild() {
 	err := LoadAndBuild("test/sass/file.scss", &BuildArgs{}, NewPartialMap())
 	if err != nil {
 		log.Fatal(err)

--- a/build_test.go
+++ b/build_test.go
@@ -12,6 +12,11 @@ import (
 	"github.com/wellington/go-libsass"
 )
 
+func init() {
+	testch = make(chan struct{})
+	close(testch)
+}
+
 func TestCompileStdin_imports(t *testing.T) {
 
 	in := bytes.NewBufferString(`@import "compass";
@@ -37,6 +42,7 @@ func TestCompileStdin_imports(t *testing.T) {
 }
 
 func TestNewBuild(t *testing.T) {
+
 	b := NewBuild([]string{"test/sass/error.scss"}, &BuildArgs{}, nil, false)
 	if b == nil {
 		t.Fatal("build is nil")
@@ -47,17 +53,34 @@ func TestNewBuild(t *testing.T) {
 		t.Errorf("got: %s wanted: %s", err, ErrPartialMap)
 	}
 	b.Close()
+}
 
-	b = NewBuild([]string{"test/sass/file.scss"}, &BuildArgs{}, NewPartialMap(), false)
+func TestNewBuild_two(t *testing.T) {
+	tdir, _ := ioutil.TempDir("", "testnewbuild_two")
+	bb := NewBuild([]string{"test/sass/file.scss"},
+		&BuildArgs{BuildDir: tdir}, NewPartialMap(), false)
 
-	err = b.Build()
-	if err == nil {
-		t.Fatal("expected error")
-	}
-	err = b.Close()
+	err := bb.Build()
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	if err != nil {
+		t.Error(err)
+	}
+
+}
+
+func TestNewBuild_dir(t *testing.T) {
+	tdir, _ := ioutil.TempDir("", "testnewbuild_two")
+	bb := NewBuild([]string{"test/sass"},
+		&BuildArgs{BuildDir: tdir}, NewPartialMap(), false)
+
+	err := bb.Build()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
 }
 
 func ExampleBuild() {

--- a/filewatcher.go
+++ b/filewatcher.go
@@ -48,22 +48,25 @@ func NewBuildArgs() BuildArgs {
 // GlobalBuildArgs contains build args that apply to all sass files.
 type Watcher struct {
 	FileWatcher *fsnotify.Watcher
-	PartialMap  *SafePartialMap
-	Dirs        []string
-	BArgs       BuildArgs
+	opts        *WatchOptions
+}
+
+type WatchOptions struct {
+	PartialMap *SafePartialMap
+	Dirs       []string
+	BArgs      BuildArgs
 }
 
 // NewWatcher returns a new watcher pointer
-func NewWatcher() *Watcher {
+func NewWatcher(opts *WatchOptions) *Watcher {
 	var fswatcher *fsnotify.Watcher
 	fswatcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		log.Fatal(err)
 	}
-
 	w := &Watcher{
+		opts:        opts,
 		FileWatcher: fswatcher,
-		PartialMap:  NewPartialMap(),
 	}
 
 	return w
@@ -101,10 +104,10 @@ func (p *SafePartialMap) AddRelation(mainfile string, subfile string) {
 // SW object that begins monitoring for file changes and triggering
 // top level sass rebuilds.
 func (w *Watcher) Watch() error {
-	if w.PartialMap == nil {
-		w.PartialMap = NewPartialMap()
+	if w.opts.PartialMap == nil {
+		w.opts.PartialMap = NewPartialMap()
 	}
-	if len(w.Dirs) == 0 {
+	if len(w.opts.Dirs) == 0 {
 		return errors.New("No directories to watch")
 	}
 	err := w.watchFiles()
@@ -118,8 +121,9 @@ func (w *Watcher) Watch() error {
 func (w *Watcher) watchFiles() error {
 	var err error
 	//Watch the dirs of all sass partials
-	w.PartialMap.RLock()
-	for k := range w.PartialMap.M {
+	w.opts.PartialMap.RLock()
+	fmt.Printf("% #v\n", w.opts.PartialMap.M)
+	for k := range w.opts.PartialMap.M {
 		dir := filepath.Dir(k)
 		_, err = os.Stat(dir)
 		if !os.IsNotExist(err) && filepath.IsAbs(dir) {
@@ -129,11 +133,11 @@ func (w *Watcher) watchFiles() error {
 			}
 		}
 	}
-	w.PartialMap.RUnlock()
+	w.opts.PartialMap.RUnlock()
 
 	//Watch the dirs of all top level files
-	for k := range w.Dirs {
-		err := w.watch(w.Dirs[k])
+	for k := range w.opts.Dirs {
+		err := w.watch(w.opts.Dirs[k])
 		if err != nil {
 			return err
 		}
@@ -182,7 +186,7 @@ func (w *Watcher) rebuild(eventFileName string) error {
 	// 		return err
 	// 	}
 	// }
-	w.PartialMap.RLock()
+	w.opts.PartialMap.RLock()
 	go func(paths []string) {
 		rebuildMu.RLock()
 		if rebuildChan != nil {
@@ -191,7 +195,7 @@ func (w *Watcher) rebuild(eventFileName string) error {
 		rebuildMu.RUnlock()
 		for i := range paths {
 			// TODO: do this in a new goroutine
-			err := LoadAndBuild(paths[i], w.BArgs, w.PartialMap)
+			err := LoadAndBuild(paths[i], w.opts.BArgs, w.opts.PartialMap)
 			if err != nil {
 				log.Println(err)
 				if errChan != nil {
@@ -199,8 +203,8 @@ func (w *Watcher) rebuild(eventFileName string) error {
 				}
 			}
 		}
-	}(w.PartialMap.M[eventFileName])
-	w.PartialMap.RUnlock()
+	}(w.opts.PartialMap.M[eventFileName])
+	w.opts.PartialMap.RUnlock()
 	return nil
 }
 

--- a/filewatcher.go
+++ b/filewatcher.go
@@ -53,8 +53,14 @@ type Watcher struct {
 
 type WatchOptions struct {
 	PartialMap *SafePartialMap
-	Dirs       []string
+	Paths      []string
 	BArgs      BuildArgs
+}
+
+func NewWatchOptions() *WatchOptions {
+	return &WatchOptions{
+		PartialMap: NewPartialMap(),
+	}
 }
 
 // NewWatcher returns a new watcher pointer
@@ -63,6 +69,9 @@ func NewWatcher(opts *WatchOptions) *Watcher {
 	fswatcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		log.Fatal(err)
+	}
+	if opts == nil {
+		opts = &WatchOptions{}
 	}
 	w := &Watcher{
 		opts:        opts,
@@ -107,8 +116,8 @@ func (w *Watcher) Watch() error {
 	if w.opts.PartialMap == nil {
 		w.opts.PartialMap = NewPartialMap()
 	}
-	if len(w.opts.Dirs) == 0 {
-		return errors.New("No directories to watch")
+	if len(w.opts.Paths) == 0 {
+		return errors.New("No paths to watch")
 	}
 	err := w.watchFiles()
 	if err != nil {
@@ -122,7 +131,7 @@ func (w *Watcher) watchFiles() error {
 	var err error
 	//Watch the dirs of all sass partials
 	w.opts.PartialMap.RLock()
-	fmt.Printf("% #v\n", w.opts.PartialMap.M)
+
 	for k := range w.opts.PartialMap.M {
 		dir := filepath.Dir(k)
 		_, err = os.Stat(dir)
@@ -136,8 +145,8 @@ func (w *Watcher) watchFiles() error {
 	w.opts.PartialMap.RUnlock()
 
 	//Watch the dirs of all top level files
-	for k := range w.opts.Dirs {
-		err := w.watch(w.opts.Dirs[k])
+	for k := range w.opts.Paths {
+		err := w.watch(w.opts.Paths[k])
 		if err != nil {
 			return err
 		}

--- a/filewatcher.go
+++ b/filewatcher.go
@@ -51,12 +51,14 @@ type Watcher struct {
 	opts        *WatchOptions
 }
 
+// WatchOptions containers the necessary parameters to run the file watcher
 type WatchOptions struct {
 	PartialMap *SafePartialMap
 	Paths      []string
 	BArgs      *BuildArgs
 }
 
+// NewWatchOptions returns a new WatchOptions
 func NewWatchOptions() *WatchOptions {
 	return &WatchOptions{
 		PartialMap: NewPartialMap(),

--- a/filewatcher.go
+++ b/filewatcher.go
@@ -54,7 +54,7 @@ type Watcher struct {
 type WatchOptions struct {
 	PartialMap *SafePartialMap
 	Paths      []string
-	BArgs      BuildArgs
+	BArgs      *BuildArgs
 }
 
 func NewWatchOptions() *WatchOptions {

--- a/filewatcher_test.go
+++ b/filewatcher_test.go
@@ -13,7 +13,9 @@ import (
 func TestRebuild(t *testing.T) {
 	var f *os.File
 	log.SetOutput(f)
-	wc := NewWatcher()
+	wc := NewWatcher(&WatchOptions{
+		PartialMap: NewPartialMap(),
+	})
 	go func(t *testing.T) {
 		select {
 		case err := <-errChan:
@@ -46,10 +48,12 @@ func TestRebuild_watch(t *testing.T) {
 	rebuildMu.Lock()
 	rebuildChan = make(chan []string, 1)
 	rebuildMu.Unlock()
-
-	w := NewWatcher()
-	w.Dirs = []string{tdir}
-	w.PartialMap.AddRelation("tswif", tfile)
+	pMap := NewPartialMap()
+	pMap.AddRelation("tswif", tfile)
+	w := NewWatcher(&WatchOptions{
+		Paths:      []string{tdir},
+		PartialMap: pMap,
+	})
 	err = w.Watch()
 	if err != nil {
 		t.Fatal(err)
@@ -74,7 +78,7 @@ func TestRebuild_watch(t *testing.T) {
 }
 
 func TestWatch(t *testing.T) {
-	w := NewWatcher()
+	w := NewWatcher(NewWatchOptions())
 	err := w.Watch()
 	if err == nil {
 		t.Error("No errors thrown for nil directories")
@@ -82,8 +86,10 @@ func TestWatch(t *testing.T) {
 	w.FileWatcher.Close()
 
 	watcherChan = make(chan string, 1)
-	w = NewWatcher()
-	w.Dirs = []string{"test"}
+	w = NewWatcher(&WatchOptions{
+		Paths:      []string{"test"},
+		PartialMap: NewPartialMap(),
+	})
 	err = w.Watch()
 
 	// Test file creation event

--- a/pather.go
+++ b/pather.go
@@ -1,0 +1,68 @@
+package wellington
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func pathsToFiles(paths []string, recurse bool) []string {
+	var rollup []string
+	for _, path := range paths {
+		if recurse {
+			paths, err := recursePath(path)
+			if err != nil {
+				fmt.Println(err)
+				continue
+			}
+			rollup = append(rollup, paths...)
+		} else {
+			rollup = append(rollup, resolvePath(path)...)
+		}
+	}
+	return rollup
+}
+
+var resolveExts = []string{".scss", ".sass"}
+
+func isImportable(name string) bool {
+	ext := filepath.Ext(name)
+
+	var match bool
+	for _, r := range resolveExts {
+		if ext == r {
+			match = true
+		}
+	}
+
+	// remove partials
+	return match && !strings.HasPrefix(name, "_")
+}
+
+// recursePath takes an input path and locates all non-partial scss/sass
+// files in it
+func recursePath(path string) ([]string, error) {
+	var paths []string
+	err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+		if !info.IsDir() && isImportable(info.Name()) {
+			paths = append(paths, path)
+		}
+		return nil
+	})
+	return paths, err
+}
+
+//
+func resolvePath(path string) []string {
+	var paths []string
+	for _, r := range resolveExts {
+		some, err := filepath.Glob(filepath.Join(path, "*"+r))
+		if err != nil {
+			continue
+		}
+		paths = append(paths, some...)
+	}
+
+	return paths
+}

--- a/pather.go
+++ b/pather.go
@@ -45,6 +45,9 @@ func isImportable(name string) bool {
 func recursePath(path string) ([]string, error) {
 	var paths []string
 	err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+		if info == nil {
+			return fmt.Errorf("invalid file found: %s", path)
+		}
 		if !info.IsDir() && isImportable(info.Name()) {
 			paths = append(paths, path)
 		}

--- a/pather_test.go
+++ b/pather_test.go
@@ -1,0 +1,37 @@
+package wellington
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestPath_recurse(t *testing.T) {
+
+	paths := pathsToFiles([]string{"test/includes"}, true)
+	if len(paths) != 1 {
+		t.Fatal("wrong number of returned paths")
+	}
+
+	// This is going to be a really annoying test, should setup a special
+	// directory to test this.
+	paths = pathsToFiles([]string{"test"}, true)
+	if e := 15; len(paths) != e {
+		t.Errorf("got: %d wanted: %d", len(paths), e)
+	}
+	fmt.Println(paths)
+}
+
+func TestPath_files(t *testing.T) {
+
+	paths := pathsToFiles([]string{"test/includes"}, false)
+	if len(paths) != 1 {
+		t.Fatal("wrong number of returned paths")
+	}
+
+	// This is going to be a really annoying test, should setup a special
+	// directory to test this.
+	paths = pathsToFiles([]string{"test"}, false)
+	if e := 2; len(paths) != e {
+		t.Errorf("got: %d wanted: %d", len(paths), e)
+	}
+}

--- a/pather_test.go
+++ b/pather_test.go
@@ -1,9 +1,6 @@
 package wellington
 
-import (
-	"fmt"
-	"testing"
-)
+import "testing"
 
 func TestPath_recurse(t *testing.T) {
 
@@ -18,7 +15,6 @@ func TestPath_recurse(t *testing.T) {
 	if e := 15; len(paths) != e {
 		t.Errorf("got: %d wanted: %d", len(paths), e)
 	}
-	fmt.Println(paths)
 }
 
 func TestPath_files(t *testing.T) {

--- a/wt/main.go
+++ b/wt/main.go
@@ -344,12 +344,8 @@ func Run(cmd *cobra.Command, paths []string) {
 		return
 	}
 	sassPaths := paths
-	bOpts := &wt.BuildOptions{
-		Async:      multi,
-		Paths:      paths,
-		BArgs:      gba,
-		PartialMap: pMap,
-	}
+
+	bOpts := wt.NewBuild(paths, &gba, pMap, multi)
 
 	err := bOpts.Build()
 	if err != nil {
@@ -361,7 +357,7 @@ func Run(cmd *cobra.Command, paths []string) {
 
 			PartialMap: pMap,
 			Paths:      sassPaths,
-			BArgs:      gba,
+			BArgs:      &gba,
 		})
 		w.Watch()
 

--- a/wt/main.go
+++ b/wt/main.go
@@ -158,7 +158,7 @@ func main() {
 }
 
 // Run is the main entrypoint for the cli.
-func Run(cmd *cobra.Command, files []string) {
+func Run(cmd *cobra.Command, paths []string) {
 
 	start := time.Now()
 
@@ -199,7 +199,7 @@ func Run(cmd *cobra.Command, files []string) {
 		}()
 	}
 
-	for _, v := range files {
+	for _, v := range paths {
 		if strings.HasPrefix(v, "-") {
 			log.Fatalf("Please specify flags before other arguments: %s", v)
 		}
@@ -311,20 +311,20 @@ func Run(cmd *cobra.Command, files []string) {
 		pat := filepath.Join(includes, "**/*.scss")
 		rotFiles, _ := filepath.Glob(rot)
 		patFiles, _ := filepath.Glob(pat)
-		files = append(rotFiles, patFiles...)
+		paths = append(rotFiles, patFiles...)
 		// Probably a better way to do this, but I'm impatient
 
-		clean := make([]string, 0, len(files))
+		clean := make([]string, 0, len(paths))
 
-		for _, file := range files {
-			if !strings.HasPrefix(filepath.Base(file), "_") {
-				clean = append(clean, file)
+		for _, p := range paths {
+			if !strings.HasPrefix(filepath.Base(p), "_") {
+				clean = append(clean, p)
 			}
 		}
-		files = clean
+		paths = clean
 	}
 
-	if len(files) == 0 && len(config) == 0 {
+	if !watch && len(paths) == 0 && len(config) == 0 {
 
 		// Read from stdin
 		fmt.Println("Reading from stdin, -h for help")
@@ -345,9 +345,9 @@ func Run(cmd *cobra.Command, files []string) {
 	}
 
 	var wg sync.WaitGroup
-	sassPaths := make([]string, len(files))
+	sassPaths := make([]string, len(paths))
 	if multi {
-		for i, f := range files {
+		for i, f := range paths {
 			wg.Add(1)
 			sassPaths[i] = filepath.Dir(f)
 			go func(f string, gba wt.BuildArgs, pMap *wt.SafePartialMap) {
@@ -360,9 +360,14 @@ func Run(cmd *cobra.Command, files []string) {
 			}(f, gba, pMap)
 		}
 	} else {
-		for i, f := range files {
+		for i, f := range paths {
+			// Hacky way to check if this is a directory
+			dir := filepath.Dir(f)
+			sassPaths[i] = dir
+			if dir == f {
+				continue
+			}
 			wg.Add(1)
-			sassPaths[i] = filepath.Dir(f)
 			// ppMap := wt.NewPartialMap()
 			err := wt.LoadAndBuild(f, gba, pMap)
 			wg.Done()
@@ -375,10 +380,12 @@ func Run(cmd *cobra.Command, files []string) {
 	}
 
 	if watch {
-		w := wt.NewWatcher()
-		w.PartialMap = pMap
-		w.Dirs = sassPaths
-		w.BArgs = gba
+		w := wt.NewWatcher(&wt.WatchOptions{
+			// TODO: not currently used
+			PartialMap: pMap,
+			Dirs:       sassPaths,
+			BArgs:      gba,
+		})
 		w.Watch()
 
 		fmt.Println("File watcher started use `ctrl+d` to exit")

--- a/wt/main.go
+++ b/wt/main.go
@@ -381,9 +381,8 @@ func Run(cmd *cobra.Command, paths []string) {
 
 	if watch {
 		w := wt.NewWatcher(&wt.WatchOptions{
-			// TODO: not currently used
 			PartialMap: pMap,
-			Dirs:       sassPaths,
+			Paths:      sassPaths,
 			BArgs:      gba,
 		})
 		w.Watch()


### PR DESCRIPTION
This will add the ability to pass directories to sub commands `compile` `watch`. Currently, you must specify every top level scss file. This is a bit dumb and limiting. It should instead be possible to say things like:

- [x] Support directories
- [x] Recursively find all [^_].+\.scss files in sub directories
- [x] Support files
- [x] rework docker container to look for Sass in sub folder

`wt -b build gui/sass` fixes #128 