### PR TITLE
Fix CPU racing issue Watcher loop

### DIFF
--- a/filewatcher.go
+++ b/filewatcher.go
@@ -150,8 +150,6 @@ func (w *Watcher) startWatching() {
 	go func() {
 		for {
 			select {
-			default:
-				// only called when w.FileWatcher.Events is set to nil.
 			case event := <-w.FileWatcher.Events:
 				if watcherChan != nil {
 					watcherChan <- event.Name


### PR DESCRIPTION
The `select` statement in the main watcher loop should not have a `default` case defined; otherwise, CPU usage goes through the roof.

Fixes #149