### PR TITLE
Start of supporting fsevents within Wellington

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,6 @@ TESTPATHS = $(shell go list -f '{{if len .TestGoFiles}}{{.ImportPath}}{{end}}' .
 
 .PHONY: gover.coverprofile
 gover.coverprofile:
-	go get golang.org/x/tools/cmd/vet
 	# retrieve lint and test deps
 	go get github.com/axw/gocov/gocov
 	go get github.com/mattn/goveralls

--- a/filewatcher.go
+++ b/filewatcher.go
@@ -1,0 +1,171 @@
+package wellington
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// MaxTopLevel sets the default size of the slice holding the top level
+// files for a sass partial in SafePartialMap.M
+const MaxTopLevel int = 20
+
+// WatchOptions containers the necessary parameters to run the file watcher
+type WatchOptions struct {
+	PartialMap *SafePartialMap
+	Paths      []string
+	BArgs      *BuildArgs
+}
+
+// NewWatchOptions returns a new WatchOptions
+func NewWatchOptions() *WatchOptions {
+	return &WatchOptions{
+		PartialMap: NewPartialMap(),
+	}
+}
+
+// NewWatcher returns a new watcher pointer
+func NewWatcher(opts *WatchOptions) (*Watcher, error) {
+	if opts == nil {
+		opts = &WatchOptions{}
+	}
+	w := &Watcher{
+		opts:    opts,
+		errChan: make(chan error),
+	}
+	w.Init()
+	// FIXME: this will leak routines, but watcher should only be
+	// called once
+	go func() {
+		for {
+			select {
+			case err := <-w.errChan:
+				log.Println("watcher: build error:", err)
+			}
+		}
+	}()
+
+	return w, nil
+}
+
+// SafePartialMap is a thread safe map of partial sass files to top
+// level files. The file watcher will detect changes in a partial and
+// kick off builds for all top level files that contain that partial.
+type SafePartialMap struct {
+	sync.RWMutex
+	M map[string][]string
+}
+
+// NewPartialMap creates a initialized SafeParitalMap with with capacity 100
+func NewPartialMap() *SafePartialMap {
+	spm := &SafePartialMap{
+		M: make(map[string][]string, 100)}
+	return spm
+}
+
+// Add places a path in the partial map
+func (p *SafePartialMap) Add(key string, paths []string) {
+	p.Lock()
+	defer p.Unlock()
+	p.M[key] = paths
+}
+
+// Get is a thread-safe way to access the partial map
+func (p *SafePartialMap) Get(key string) ([]string, bool) {
+	p.RLock()
+	defer p.RUnlock()
+	pm, ok := p.M[key]
+	return pm, ok
+}
+
+// AddRelation links a partial Sass file with the top level file by
+// adding a thread safe entry into partialMap.M.
+func (p *SafePartialMap) AddRelation(mainfile string, subfile string) {
+	existing, _ := p.Get(subfile)
+	p.Add(subfile, appendUnique(existing, mainfile))
+}
+
+var watcherChan chan (string)
+
+// Watch is the main entry point into filewatcher and sets up the
+// SW object that begins monitoring for file changes and triggering
+// top level sass rebuilds.
+func (w *Watcher) Watch() error {
+	if w.opts.PartialMap == nil {
+		w.opts.PartialMap = NewPartialMap()
+	}
+
+	if len(w.opts.Paths) == 0 {
+		return errors.New("No paths to watch")
+	}
+	err := w.watchFiles()
+	if err != nil {
+		return err
+	}
+	w.startWatching()
+	return nil
+}
+
+func (w *Watcher) watchFiles() error {
+	var err error
+	//Watch the dirs of all sass partials
+	w.opts.PartialMap.RLock()
+	for k := range w.opts.PartialMap.M {
+		dir := filepath.Dir(k)
+		_, err = os.Stat(dir)
+		if !os.IsNotExist(err) && filepath.IsAbs(dir) {
+			err = w.watch(dir)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	w.opts.PartialMap.RUnlock()
+	return nil
+}
+
+var rebuildMu sync.RWMutex
+var rebuildChan chan ([]string)
+
+// rebuild is notified about sass file updates and looks
+// for the file in the partial map.  It also checks
+// for whether the file is a non-partial, no _ at beginning,
+// and requests the file be rebuilt directly.
+func (w *Watcher) rebuild(eventFileName string) error {
+	paths, ok := w.opts.PartialMap.Get(eventFileName)
+	if !ok {
+		// This isn't an error per say, so let's ignore it
+		return nil
+		return fmt.Errorf("partial map lookup failed: %s", eventFileName)
+	}
+
+	go func(paths []string) {
+		rebuildMu.RLock()
+		if rebuildChan != nil {
+			rebuildChan <- paths
+		}
+		rebuildMu.RUnlock()
+		for i := range paths {
+			// TODO: do this in a new goroutine
+			err := LoadAndBuild(paths[i], w.opts.BArgs, w.opts.PartialMap)
+			if err != nil {
+				w.errChan <- err
+			} else {
+				fmt.Printf("Rebuilt: %s\n", paths[i])
+			}
+		}
+	}(paths)
+	return nil
+}
+
+func appendUnique(slice []string, s string) []string {
+	for _, ele := range slice {
+		if ele == s {
+			return slice
+		}
+	}
+	return append(slice, s)
+}

--- a/filewatcher.go
+++ b/filewatcher.go
@@ -139,7 +139,7 @@ func (w *Watcher) rebuild(eventFileName string) error {
 	if !ok {
 		// This isn't an error per say, so let's ignore it
 		return nil
-		return fmt.Errorf("partial map lookup failed: %s", eventFileName)
+		// return fmt.Errorf("partial map lookup failed: %s", eventFileName)
 	}
 
 	go func(paths []string) {

--- a/filewatcher_darwin.go
+++ b/filewatcher_darwin.go
@@ -3,20 +3,12 @@
 package wellington
 
 import (
-	"errors"
-	"fmt"
 	"log"
-	"os"
 	"path/filepath"
-	"sync"
 	"time"
 
 	"github.com/fsnotify/fsevents"
 )
-
-// MaxTopLevel sets the default size of the slice holding the top level
-// files for a sass partial in SafePartialMap.M
-const MaxTopLevel int = 20
 
 // Watcher holds all data needed to kick off a build of the css when a
 // file changes.
@@ -25,193 +17,69 @@ const MaxTopLevel int = 20
 // Dirs contains all directories that have top level files.
 // GlobalBuildArgs contains build args that apply to all sass files.
 type Watcher struct {
-	es *fsevents.EventStream
-	// fw      *fsnotify.Watcher
+	es      *fsevents.EventStream
 	opts    *WatchOptions
 	errChan chan error
 }
 
-// WatchOptions containers the necessary parameters to run the file watcher
-type WatchOptions struct {
-	PartialMap *SafePartialMap
-	Paths      []string
-	BArgs      *BuildArgs
-}
-
-// NewWatchOptions returns a new WatchOptions
-func NewWatchOptions() *WatchOptions {
-	return &WatchOptions{
-		PartialMap: NewPartialMap(),
+// Init initializes the watcher with fsevent watcher
+func (w *Watcher) Init() {
+	if w.es != nil {
+		w.es.Stop()
+	}
+	w.es = &fsevents.EventStream{
+		Latency: 500 * time.Millisecond,
+		Flags:   fsevents.FileEvents,
 	}
 }
-
-// NewWatcher returns a new watcher pointer
-func NewWatcher(opts *WatchOptions) (*Watcher, error) {
-	if opts == nil {
-		opts = &WatchOptions{}
-	}
-	w := &Watcher{
-		opts: opts,
-		es: &fsevents.EventStream{
-			Latency: 500 * time.Millisecond,
-			Flags:   fsevents.FileEvents | fsevents.WatchRoot,
-		},
-		errChan: make(chan error),
-	}
-	// FIXME: this will leak routines, but watcher should only be
-	// called once
-	go func() {
-		for {
-			select {
-			case err := <-w.errChan:
-				log.Println("watcher: build error:", err)
-			}
-		}
-	}()
-
-	return w, nil
-}
-
-// SafePartialMap is a thread safe map of partial sass files to top
-// level files. The file watcher will detect changes in a partial and
-// kick off builds for all top level files that contain that partial.
-type SafePartialMap struct {
-	sync.RWMutex
-	M map[string][]string
-}
-
-// NewPartialMap creates a initialized SafeParitalMap with with capacity 100
-func NewPartialMap() *SafePartialMap {
-	spm := &SafePartialMap{
-		M: make(map[string][]string, 100)}
-	return spm
-}
-
-// Add places a path in the partial map
-func (p *SafePartialMap) Add(key string, paths []string) {
-	p.Lock()
-	defer p.Unlock()
-	p.M[key] = paths
-}
-
-// Get is a thread-safe way to access the partial map
-func (p *SafePartialMap) Get(key string) ([]string, bool) {
-	p.RLock()
-	defer p.RUnlock()
-	pm, ok := p.M[key]
-	return pm, ok
-}
-
-// AddRelation links a partial Sass file with the top level file by
-// adding a thread safe entry into partialMap.M.
-func (p *SafePartialMap) AddRelation(mainfile string, subfile string) {
-	existing, _ := p.Get(subfile)
-	p.Add(subfile, appendUnique(existing, mainfile))
-}
-
-// Watch is the main entry point into filewatcher and sets up the
-// SW object that begins monitoring for file changes and triggering
-// top level sass rebuilds.
-func (w *Watcher) Watch() error {
-	if w.opts.PartialMap == nil {
-		w.opts.PartialMap = NewPartialMap()
-	}
-
-	if len(w.opts.Paths) == 0 {
-		return errors.New("No paths to watch")
-	}
-	err := w.watchFiles()
-	if err != nil {
-		return err
-	}
-	w.startWatching()
-	return nil
-}
-
-func (w *Watcher) watchFiles() error {
-	var err error
-	//Watch the dirs of all sass partials
-	w.opts.PartialMap.RLock()
-	for k := range w.opts.PartialMap.M {
-		dir := filepath.Dir(k)
-		_, err = os.Stat(dir)
-		if !os.IsNotExist(err) && filepath.IsAbs(dir) {
-			err = w.watch(dir)
-			if err != nil {
-				return err
-			}
-		}
-	}
-	w.opts.PartialMap.RUnlock()
-	return nil
-}
-
-var watcherChan chan (string)
 
 func (w *Watcher) startWatching() {
+
 	go func() {
 		log.Println("starting up...")
 		w.es.Start()
 		ec := w.es.Events
 		log.Println("watching", w.es.Paths)
+
 		for msg := range ec {
-			log.Println("msg", msg)
 			for _, event := range msg {
-				log.Printf("% #v\n", event)
+				ext := filepath.Ext(event.Path)
+				if ext == ".scss" || ext == ".sass" {
+					if !checkFlag(event.Flags) {
+						log.Println("ignoring fsevent", event.Flags, "on", event.Path)
+						continue
+					}
+					log.Println("Path", event.Path)
+					log.Println("Flags", event.Flags)
+					err := w.rebuild(event.Path)
+					if err != nil {
+						log.Println("rebuild error:", err)
+					}
+				}
 			}
 		}
-		// for {
-		// 	select {
-		// 	case event := <-w.fw.Events:
-		// 		if watcherChan != nil {
-		// 			watcherChan <- event.Name
-		// 			return
-		// 		}
-		// 		if event.Op&fsnotify.Write == fsnotify.Write {
-		// 			err := w.rebuild(event.Name)
-		// 			if err != nil {
-		// 				log.Println("rebuild error:", err)
-		// 			}
-		// 		}
-		// 	case err := <-w.fw.Errors:
-		// 		if err != nil {
-		// 			log.Println("filewatcher error:", err)
-		// 		}
-		// 	}
-		// }
 	}()
 }
 
-var rebuildMu sync.RWMutex
-var rebuildChan chan ([]string)
+var modEvts = []fsevents.EventFlags{
+	fsevents.ItemCreated,
+	fsevents.ItemRemoved,
+	fsevents.ItemRenamed,
+	fsevents.ItemModified,
+}
 
-// rebuild is notified about sass file updates and looks
-// for the file in the partial map.  It also checks
-// for whether the file is a non-partial, no _ at beginning,
-// and requests the file be rebuilt directly.
-func (w *Watcher) rebuild(eventFileName string) error {
-	paths, ok := w.opts.PartialMap.Get(eventFileName)
-	if !ok {
-		return fmt.Errorf("partial map lookup failed: %s", eventFileName)
+// checkFlag lets us know if this event is important
+func checkFlag(e fsevents.EventFlags) bool {
+	if e&fsevents.ItemIsFile == 0 {
+		return false
 	}
 
-	go func(paths []string) {
-		rebuildMu.RLock()
-		if rebuildChan != nil {
-			rebuildChan <- paths
+	for i := range modEvts {
+		if e&modEvts[i] == modEvts[i] {
+			return true
 		}
-		rebuildMu.RUnlock()
-		for i := range paths {
-			// TODO: do this in a new goroutine
-			err := LoadAndBuild(paths[i], w.opts.BArgs, w.opts.PartialMap)
-			if err != nil {
-				w.errChan <- err
-			} else {
-				fmt.Printf("Rebuilt: %s\n", paths[i])
-			}
-		}
-	}(paths)
-	return nil
+	}
+	return false
 }
 
 func (w *Watcher) watch(fpath string) error {
@@ -220,13 +88,4 @@ func (w *Watcher) watch(fpath string) error {
 		w.es.Paths = appendUnique(w.es.Paths, fpath)
 	}
 	return nil
-}
-
-func appendUnique(slice []string, s string) []string {
-	for _, ele := range slice {
-		if ele == s {
-			return slice
-		}
-	}
-	return append(slice, s)
 }

--- a/filewatcher_notdarwin.go
+++ b/filewatcher_notdarwin.go
@@ -22,9 +22,9 @@ const MaxTopLevel int = 20
 // Dirs contains all directories that have top level files.
 // GlobalBuildArgs contains build args that apply to all sass files.
 type Watcher struct {
-	FileWatcher *fsnotify.Watcher
-	opts        *WatchOptions
-	errChan     chan error
+	fw      *fsnotify.Watcher
+	opts    *WatchOptions
+	errChan chan error
 }
 
 // WatchOptions containers the necessary parameters to run the file watcher
@@ -52,9 +52,9 @@ func NewWatcher(opts *WatchOptions) (*Watcher, error) {
 		opts = &WatchOptions{}
 	}
 	w := &Watcher{
-		opts:        opts,
-		FileWatcher: fswatcher,
-		errChan:     make(chan error),
+		opts:    opts,
+		fw:      fswatcher,
+		errChan: make(chan error),
 	}
 	// FIXME: this will leak routines, but watcher should only be
 	// called once
@@ -150,7 +150,7 @@ func (w *Watcher) startWatching() {
 	go func() {
 		for {
 			select {
-			case event := <-w.FileWatcher.Events:
+			case event := <-w.fw.Events:
 				if watcherChan != nil {
 					watcherChan <- event.Name
 					return
@@ -161,7 +161,7 @@ func (w *Watcher) startWatching() {
 						log.Println("rebuild error:", err)
 					}
 				}
-			case err := <-w.FileWatcher.Errors:
+			case err := <-w.fw.Errors:
 				if err != nil {
 					log.Println("filewatcher error:", err)
 				}
@@ -204,7 +204,7 @@ func (w *Watcher) rebuild(eventFileName string) error {
 
 func (w *Watcher) watch(fpath string) error {
 	if len(fpath) > 0 {
-		if err := w.FileWatcher.Add(fpath); nil != err {
+		if err := w.fw.Add(fpath); nil != err {
 			return err
 		}
 	}

--- a/filewatcher_notdarwin.go
+++ b/filewatcher_notdarwin.go
@@ -3,19 +3,11 @@
 package wellington
 
 import (
-	"errors"
 	"fmt"
 	"log"
-	"os"
-	"path/filepath"
-	"sync"
 
 	"gopkg.in/fsnotify.v1"
 )
-
-// MaxTopLevel sets the default size of the slice holding the top level
-// files for a sass partial in SafePartialMap.M
-const MaxTopLevel int = 20
 
 // Watcher holds all data needed to kick off a build of the css when a
 // file changes.
@@ -29,124 +21,14 @@ type Watcher struct {
 	errChan chan error
 }
 
-// WatchOptions containers the necessary parameters to run the file watcher
-type WatchOptions struct {
-	PartialMap *SafePartialMap
-	Paths      []string
-	BArgs      *BuildArgs
-}
-
-// NewWatchOptions returns a new WatchOptions
-func NewWatchOptions() *WatchOptions {
-	return &WatchOptions{
-		PartialMap: NewPartialMap(),
-	}
-}
-
-// NewWatcher returns a new watcher pointer
-func NewWatcher(opts *WatchOptions) (*Watcher, error) {
-	var fswatcher *fsnotify.Watcher
-	fswatcher, err := fsnotify.NewWatcher()
-	if err != nil {
-		return nil, err
-	}
-	if opts == nil {
-		opts = &WatchOptions{}
-	}
-	w := &Watcher{
-		opts:    opts,
-		fw:      fswatcher,
-		errChan: make(chan error),
-	}
-	// FIXME: this will leak routines, but watcher should only be
-	// called once
-	go func() {
-		for {
-			select {
-			case err := <-w.errChan:
-				log.Println("watcher: build error:", err)
-			}
-		}
-	}()
-
-	return w, nil
-}
-
-// SafePartialMap is a thread safe map of partial sass files to top
-// level files. The file watcher will detect changes in a partial and
-// kick off builds for all top level files that contain that partial.
-type SafePartialMap struct {
-	sync.RWMutex
-	M map[string][]string
-}
-
-// NewPartialMap creates a initialized SafeParitalMap with with capacity 100
-func NewPartialMap() *SafePartialMap {
-	spm := &SafePartialMap{
-		M: make(map[string][]string, 100)}
-	return spm
-}
-
-// Add places a path in the partial map
-func (p *SafePartialMap) Add(key string, paths []string) {
-	p.Lock()
-	defer p.Unlock()
-	p.M[key] = paths
-}
-
-// Get is a thread-safe way to access the partial map
-func (p *SafePartialMap) Get(key string) ([]string, bool) {
-	p.RLock()
-	defer p.RUnlock()
-	pm, ok := p.M[key]
-	return pm, ok
-}
-
-// AddRelation links a partial Sass file with the top level file by
-// adding a thread safe entry into partialMap.M.
-func (p *SafePartialMap) AddRelation(mainfile string, subfile string) {
-	existing, _ := p.Get(subfile)
-	p.Add(subfile, appendUnique(existing, mainfile))
-}
-
-// Watch is the main entry point into filewatcher and sets up the
-// SW object that begins monitoring for file changes and triggering
-// top level sass rebuilds.
-func (w *Watcher) Watch() error {
-	if w.opts.PartialMap == nil {
-		w.opts.PartialMap = NewPartialMap()
-	}
-
-	if len(w.opts.Paths) == 0 {
-		return errors.New("No paths to watch")
-	}
-	err := w.watchFiles()
-	if err != nil {
-		return err
-	}
-	w.startWatching()
-	return nil
-}
-
-func (w *Watcher) watchFiles() error {
+// Init initializes the watcher with fsnotify watcher
+func (w *Watcher) Init() {
 	var err error
-	//Watch the dirs of all sass partials
-	w.opts.PartialMap.RLock()
-	for k := range w.opts.PartialMap.M {
-		dir := filepath.Dir(k)
-		_, err = os.Stat(dir)
-		if !os.IsNotExist(err) && filepath.IsAbs(dir) {
-			err = w.watch(dir)
-			if err != nil {
-				return err
-			}
-		}
+	w.fw, err = fsnotify.NewWatcher()
+	if err != nil {
+		log.Fatal(err)
 	}
-	w.opts.PartialMap.RUnlock()
-	return nil
 }
-
-var watcherChan chan (string)
 
 func (w *Watcher) startWatching() {
 	go func() {
@@ -172,52 +54,12 @@ func (w *Watcher) startWatching() {
 	}()
 }
 
-var rebuildMu sync.RWMutex
-var rebuildChan chan ([]string)
-
-// rebuild is notified about sass file updates and looks
-// for the file in the partial map.  It also checks
-// for whether the file is a non-partial, no _ at beginning,
-// and requests the file be rebuilt directly.
-func (w *Watcher) rebuild(eventFileName string) error {
-	paths, ok := w.opts.PartialMap.Get(eventFileName)
-	if !ok {
-		return fmt.Errorf("partial map lookup failed: %s", eventFileName)
-	}
-
-	go func(paths []string) {
-		rebuildMu.RLock()
-		if rebuildChan != nil {
-			rebuildChan <- paths
-		}
-		rebuildMu.RUnlock()
-		for i := range paths {
-			// TODO: do this in a new goroutine
-			err := LoadAndBuild(paths[i], w.opts.BArgs, w.opts.PartialMap)
-			if err != nil {
-				w.errChan <- err
-			} else {
-				fmt.Printf("Rebuilt: %s\n", paths[i])
-			}
-		}
-	}(paths)
-	return nil
-}
-
 func (w *Watcher) watch(fpath string) error {
 	if len(fpath) > 0 {
+		fmt.Println("append", fpath)
 		if err := w.fw.Add(fpath); nil != err {
 			return err
 		}
 	}
 	return nil
-}
-
-func appendUnique(slice []string, s string) []string {
-	for _, ele := range slice {
-		if ele == s {
-			return slice
-		}
-	}
-	return append(slice, s)
 }

--- a/filewatcher_test.go
+++ b/filewatcher_test.go
@@ -92,7 +92,7 @@ func TestWatch(t *testing.T) {
 	if err == nil {
 		t.Error("No errors thrown for nil directories")
 	}
-	w.FileWatcher.Close()
+	w.fw.Close()
 
 	watcherChan = make(chan string, 1)
 	w, err = NewWatcher(&WatchOptions{

--- a/filewatcher_test.go
+++ b/filewatcher_test.go
@@ -92,7 +92,7 @@ func TestWatch(t *testing.T) {
 	if err == nil {
 		t.Error("No errors thrown for nil directories")
 	}
-	w.fw.Close()
+	// w.fw.Close()
 
 	watcherChan = make(chan string, 1)
 	w, err = NewWatcher(&WatchOptions{


### PR DESCRIPTION
Some applications ie. textedit only send fsevent based file notifications. Because of this, the fsnotify file watcher does not pick up changes to files. By tapping github.com/fsnotify/fsevents directly, we can support darwin fsevents with OS X. OS X is the primary platform of wt, so this support is essential.

fixes #182 